### PR TITLE
Added a service provider allowing the session to function correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,46 @@ class Kernel extends Http\Kernel
     ];
 ...
 ```
+Replace the original session service provider in ```config/app.php```
+
+```php
+'providers' => [
+    /*
+     * Laravel Framework Service Providers...
+     */
+    'Illuminate\Foundation\Providers\ArtisanServiceProvider',
+    'Illuminate\Auth\AuthServiceProvider',
+    'Illuminate\Bus\BusServiceProvider',
+    'Illuminate\Cache\CacheServiceProvider',
+    'Illuminate\Foundation\Providers\ConsoleSupportServiceProvider',
+    'Illuminate\Routing\ControllerServiceProvider',
+    'Illuminate\Cookie\CookieServiceProvider',
+    'Illuminate\Database\DatabaseServiceProvider',
+    'Illuminate\Encryption\EncryptionServiceProvider',
+    'Illuminate\Filesystem\FilesystemServiceProvider',
+    'Illuminate\Foundation\Providers\FoundationServiceProvider',
+    'Illuminate\Hashing\HashServiceProvider',
+    'Illuminate\Mail\MailServiceProvider',
+    'Illuminate\Pagination\PaginationServiceProvider',
+    'Illuminate\Pipeline\PipelineServiceProvider',
+    'Illuminate\Queue\QueueServiceProvider',
+    'Illuminate\Redis\RedisServiceProvider',
+    'Illuminate\Auth\Passwords\PasswordResetServiceProvider',
+    //'Illuminate\Session\SessionServiceProvider',
+    'Illuminate\Translation\TranslationServiceProvider',
+    'Illuminate\Validation\ValidationServiceProvider',
+    'Illuminate\View\ViewServiceProvider',
+    /*
+     * Application Service Providers...
+     */
+    'Kevinsimard\CookielessSession\Providers\SessionServiceProvider',
+    'App\Providers\AppServiceProvider',
+    'App\Providers\BusServiceProvider',
+    'App\Providers\ConfigServiceProvider',
+    'App\Providers\EventServiceProvider',
+    'App\Providers\RouteServiceProvider',
+],
+```
 
 ## Code Structure
     ┌── src/
@@ -32,6 +72,8 @@ class Kernel extends Http\Kernel
     │       └── CookielessSession/
     │           └── Middleware/
     │               └── StartSession.php
+                └── Providers/
+    │               └── SessionServiceProvider.php
     ├── .gitattributes
     ├── .gitignore
     ├── composer.json

--- a/src/Kevinsimard/CookielessSession/Providers/SessionServiceProvider.php
+++ b/src/Kevinsimard/CookielessSession/Providers/SessionServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Kevinsimard\CookielessSession\Providers;
+
+use Illuminate\Session\SessionServiceProvider as OriginalServiceProvider;
+
+class SessionServiceProvider extends OriginalServiceProvider
+{
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerSessionManager();
+
+        $this->registerSessionDriver();
+
+        $this->app->singleton('Kevinsimard\CookielessSession\Middleware\StartSession');
+    }
+}


### PR DESCRIPTION
I have added a service provider which allows your cookieless session to function correctly. Previously, when you attempted to get values from session, they would be missing. The original Laravel service provider still referenced the original StartSession middleware. I have added a new service provider which extends the original but references your middleware.

I have also updated the readme file with regards to the new provider.
